### PR TITLE
Counting the images without fetching images (way faster)

### DIFF
--- a/server.go
+++ b/server.go
@@ -148,11 +148,11 @@ func getCountryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type Count struct {
-		count int
+		Count int64
 	}
 
 	enc := json.NewEncoder(w)
-	err = enc.Encode(Count{count: count})
+	err = enc.Encode(Count{Count: count})
 
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
* No need for fetching the images (and load balancing). It is known that each url from BigQuery has 13 images, so we can just get the number of urls using SQL aggregate function count, add them up and at then multiply with 13. The BigQuery requests are done concurrently with a goroutine for each Rectangle.
* Also fixed the JSON response